### PR TITLE
Initial setup of python package and server extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/build
+*.egg-info
+.idea
+__pycache__
+.coverage

--- a/aws_jupyter_proxy/__init__.py
+++ b/aws_jupyter_proxy/__init__.py
@@ -1,0 +1,9 @@
+from aws_jupyter_proxy.handlers import setup_handlers
+
+
+def _jupyter_server_extension_paths():
+    return [{"module": "aws_jupyter_proxy"}]
+
+
+def load_jupyter_server_extension(nbapp):
+    setup_handlers(nbapp.web_app)

--- a/aws_jupyter_proxy/etc/aws_jupyter_proxy.json
+++ b/aws_jupyter_proxy/etc/aws_jupyter_proxy.json
@@ -1,0 +1,7 @@
+{
+  "NotebookApp": {
+    "nbserver_extensions": {
+      "aws_jupyter_proxy": true
+    }
+  }
+}

--- a/aws_jupyter_proxy/handlers.py
+++ b/aws_jupyter_proxy/handlers.py
@@ -1,0 +1,27 @@
+from boto3 import Session
+from notebook.base.handlers import APIHandler
+from notebook.utils import url_path_join
+
+
+class AwsProxyHandler(APIHandler):
+
+    def initialize(self, session: Session):
+        """
+        Hook for Tornado handler initialization.
+        :param session: the botocore session
+        """
+        self.session = session
+
+    def get(self, *args):
+        self.log.info('GET invoked')
+
+
+awsproxy_handlers = [(r'/awsproxy(.*)',
+                      AwsProxyHandler,
+                      dict(session=Session()))]
+
+
+def setup_handlers(web_app):
+    base_url = web_app.settings['base_url']
+    web_app.add_handlers(".*", [(url_path_join(base_url, path), handler, data) for (path, handler, data) in
+                                awsproxy_handlers])

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,24 @@
+import setuptools
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name="aws_jupyter_proxy",
+    version='0.1.0',
+    url="https://github.com/aws/aws-jupyter-proxy",
+    author="Amazon Web Services",
+    description="A Jupyter server extension to proxy requests with AWS SigV4 authentication",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    packages=setuptools.find_packages(),
+    license="Apache License 2.0",
+    install_requires=[
+        'notebook >=6.0, <7.0',
+        'botocore >=1.0, <2.0'
+    ],
+    data_files=[
+        ('etc/jupyter/jupyter_notebook_config.d', ['aws_jupyter_proxy/etc/aws_jupyter_proxy.json']),
+    ],
+    include_package_data=True
+)


### PR DESCRIPTION

*Description of changes:*

This make the package pip-installable and sets up a basic handler for the server extension. In the next commit/PR, I'll port over the existing code.

*Testing Done*

* `pip install .` works
* curl'ing the /awsproxy endpoint shows up the log in the Jupyter logs



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
