### PR TITLE
Misc changes to correctly proxy S3 requests

### DIFF
--- a/tests/unit/test_awsproxy.py
+++ b/tests/unit/test_awsproxy.py
@@ -59,10 +59,12 @@ async def test_post_with_body(mock_fetch, mock_session):
                                'X-Amz-Security-Token': 'session_token',
                                'Host': 'api.sagemaker.us-west-2.amazonaws.com'
                            },
-                           follow_redirects=False
+                           follow_redirects=False,
+                           allow_nonstandard_methods=True
                            )
 
     assert_http_response(mock_fetch, expected)
+
 
 @pytest.mark.asyncio
 @patch('tornado.httpclient.AsyncHTTPClient.fetch', new_callable=CoroutineMock)
@@ -137,10 +139,12 @@ async def test_get_with_path(mock_fetch, mock_session):
                                'X-Amz-Security-Token': 'session_token',
                                'Host': 'eks.us-east-2.amazonaws.com'
                            },
-                           follow_redirects=False
+                           follow_redirects=False,
+                           allow_nonstandard_methods=True
                            )
 
     assert_http_response(mock_fetch, expected)
+
 
 @pytest.mark.asyncio
 @patch('tornado.httpclient.AsyncHTTPClient.fetch', new_callable=CoroutineMock)
@@ -184,10 +188,12 @@ async def test_get_with_query(mock_fetch, mock_session):
                                'X-Amz-Security-Token': 'session_token',
                                'Host': 'eks.us-east-2.amazonaws.com'
                            },
-                           follow_redirects=False
+                           follow_redirects=False,
+                           allow_nonstandard_methods=True
                            )
 
     assert_http_response(mock_fetch, expected)
+
 
 @pytest.mark.asyncio
 @patch('tornado.httpclient.AsyncHTTPClient.fetch', new_callable=CoroutineMock)
@@ -231,10 +237,12 @@ async def test_delete(mock_fetch, mock_session):
                                'X-Amz-Security-Token': 'session_token',
                                'Host': 'eks.us-east-2.amazonaws.com'
                            },
-                           follow_redirects=False
+                           follow_redirects=False,
+                           allow_nonstandard_methods=True
                            )
 
     assert_http_response(mock_fetch, expected)
+
 
 @pytest.mark.asyncio
 @patch('tornado.httpclient.AsyncHTTPClient.fetch', new_callable=CoroutineMock)
@@ -278,7 +286,210 @@ async def test_put(mock_fetch, mock_session):
                                'X-Amz-Security-Token': 'session_token',
                                'Host': 'eks.us-east-2.amazonaws.com'
                            },
-                           follow_redirects=False
+                           follow_redirects=False,
+                           allow_nonstandard_methods=True
+                           )
+
+    assert_http_response(mock_fetch, expected)
+
+
+@pytest.mark.asyncio
+@patch('tornado.httpclient.AsyncHTTPClient.fetch', new_callable=CoroutineMock)
+async def test_post_with_query_params_and_body(mock_fetch, mock_session):
+    # Given
+    upstream_request = HTTPServerRequest(
+        method='POST',
+        uri='/awsproxy/bucket-name-1/Hello.txt?select&select-type=2',
+        headers=HTTPHeaders({
+            'Authorization': 'AWS4-HMAC-SHA256 '
+                             'Credential=AKIDEXAMPLE/20190828/us-west-2/s3/aws4_request, '
+                             'SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-user-agent, '
+                             'Signature=451d7037903cee381c6a5d2c61c6ee2b5d36f35650e95abcf5e8af11b57c0cf8',
+            'Host': 'localhost:8888',
+            'X-Amz-User-Agent': 'aws-sdk-js/2.507.0 promise',
+            'X-Amz-Content-Sha256': 'f5b0fecc75eeaba2a9c92703363f4b9e3efa3f7811d3904f0b71cf05c3895228',
+            'X-Amz-Date': '20190828T173626Z'
+
+        }),
+        body=b'<SelectObjectContentRequest xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
+             b'<Expression>select * from S3Object</Expression>'
+             b'<ExpressionType>SQL</ExpressionType>'
+             b'<InputSerialization><JSON>'
+             b'<Type>Lines</Type>'
+             b'</JSON></InputSerialization>'
+             b'<OutputSerialization><JSON><RecordDelimiter>,</RecordDelimiter></JSON></OutputSerialization>'
+             b'</SelectObjectContentRequest>',
+        host='localhost:8888'
+    )
+
+    # When
+    await AwsProxyRequest(upstream_request, create_endpoint_resolver(), mock_session).execute_downstream()
+
+    # Then
+    expected = HTTPRequest(url='https://s3.us-west-2.amazonaws.com/bucket-name-1/Hello.txt?select&select-type=2',
+                           method=upstream_request.method,
+                           body=upstream_request.body,
+                           headers={
+                               'Authorization': 'AWS4-HMAC-SHA256 '
+                                                'Credential=access_key/20190828/us-west-2/s3/aws4_request, '
+                                                'SignedHeaders=host;x-amz-content-sha256;x-amz-date;'
+                                                'x-amz-security-token;x-amz-user-agent, '
+                                                'Signature='
+                                                'e55d97f45ca6862d9c2518868dd2a8c383007df1c991e42ef5950a46a4c13f8e',
+                               'X-Amz-User-Agent': upstream_request.headers['X-Amz-User-Agent'],
+                               'X-Amz-Content-Sha256': upstream_request.headers['X-Amz-Content-Sha256'],
+                               'X-Amz-Date': upstream_request.headers['X-Amz-Date'],
+                               'X-Amz-Security-Token': 'session_token',
+                               'Host': 's3.us-west-2.amazonaws.com'
+                           },
+                           follow_redirects=False,
+                           allow_nonstandard_methods=True
+                           )
+
+    assert_http_response(mock_fetch, expected)
+
+@pytest.mark.asyncio
+@patch('tornado.httpclient.AsyncHTTPClient.fetch', new_callable=CoroutineMock)
+async def test_post_with_query_params_no_body(mock_fetch, mock_session):
+    # Given
+    upstream_request = HTTPServerRequest(
+        method='POST',
+        uri='/awsproxy/bucket-name-1/Multipart-0.16441670919496487.txt?uploads',
+        headers=HTTPHeaders({
+            'Authorization': 'AWS4-HMAC-SHA256 '
+                             'Credential=AKIDEXAMPLE/20190828/us-west-2/s3/aws4_request, '
+                             'SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-user-agent, '
+                             'Signature=451d7037903cee381c6a5d2c61c6ee2b5d36f35650e95abcf5e8af11b57c0cf8',
+            'Host': 'localhost:8888',
+            'X-Amz-User-Agent': 'aws-sdk-js/2.507.0 promise',
+            'X-Amz-Content-Sha256': 'a08b81ef3b4ec5e1f65ca97d00928105c3d7eb6d50ae59fc15f0d14b64c9ec3b',
+            'X-Amz-Date': '20190828T173626Z'
+
+        }),
+        body=b'',
+        host='localhost:8888'
+    )
+
+    # When
+    await AwsProxyRequest(upstream_request, create_endpoint_resolver(), mock_session).execute_downstream()
+
+    # Then
+    expected = HTTPRequest(url='https://s3.us-west-2.amazonaws.com/bucket-name-1/Multipart-0.16441670919496487.txt'
+                               '?uploads',
+                           method=upstream_request.method,
+                           body=None,
+                           headers={
+                               'Authorization': 'AWS4-HMAC-SHA256 '
+                                                'Credential=access_key/20190828/us-west-2/s3/aws4_request, '
+                                                'SignedHeaders=host;x-amz-content-sha256;x-amz-date;'
+                                                'x-amz-security-token;x-amz-user-agent, '
+                                                'Signature='
+                                                'ba2062818cb4cd80a73dd43d006f141ede069b8ccc2ece16c20504587bd5045b',
+                               'X-Amz-User-Agent': upstream_request.headers['X-Amz-User-Agent'],
+                               'X-Amz-Content-Sha256': upstream_request.headers['X-Amz-Content-Sha256'],
+                               'X-Amz-Date': upstream_request.headers['X-Amz-Date'],
+                               'X-Amz-Security-Token': 'session_token',
+                               'Host': 's3.us-west-2.amazonaws.com'
+                           },
+                           follow_redirects=False,
+                           allow_nonstandard_methods=True
+                           )
+
+    assert_http_response(mock_fetch, expected)
+
+@pytest.mark.asyncio
+@patch('tornado.httpclient.AsyncHTTPClient.fetch', new_callable=CoroutineMock)
+async def test_head_request(mock_fetch, mock_session):
+    # Given
+    upstream_request = HTTPServerRequest(
+        method='HEAD',
+        uri='/awsproxy/bucket-name-1',
+        headers=HTTPHeaders({
+            'Authorization': 'AWS4-HMAC-SHA256 '
+                             'Credential=AKIDEXAMPLE/20190828/us-west-2/s3/aws4_request, '
+                             'SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-user-agent, '
+                             'Signature=0d02795c4feed38e5a4cd80aec3a2c67886b11797a23c307e4f52c2cfe0c137e',
+            'Host': 'localhost:8888',
+            'X-Amz-User-Agent': 'aws-sdk-js/2.507.0 promise',
+            'X-Amz-Content-Sha256': 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+            'X-Amz-Date': '20190828T173626Z'
+
+        }),
+        body=None,
+        host='localhost:8888'
+    )
+
+    # When
+    await AwsProxyRequest(upstream_request, create_endpoint_resolver(), mock_session).execute_downstream()
+
+    # Then
+    expected = HTTPRequest(url='https://s3.us-west-2.amazonaws.com/bucket-name-1',
+                           method=upstream_request.method,
+                           body=None,
+                           headers={
+                               'Authorization': 'AWS4-HMAC-SHA256 '
+                                                'Credential=access_key/20190828/us-west-2/s3/aws4_request, '
+                                                'SignedHeaders=host;x-amz-content-sha256;x-amz-date;'
+                                                'x-amz-security-token;x-amz-user-agent, '
+                                                'Signature='
+                                                '6d724e3bd64390d5d84010d6fc0f8147b3e3917c5befa3f8d1efb691b408e821',
+                               'X-Amz-User-Agent': upstream_request.headers['X-Amz-User-Agent'],
+                               'X-Amz-Content-Sha256': upstream_request.headers['X-Amz-Content-Sha256'],
+                               'X-Amz-Date': upstream_request.headers['X-Amz-Date'],
+                               'X-Amz-Security-Token': 'session_token',
+                               'Host': 's3.us-west-2.amazonaws.com'
+                           },
+                           follow_redirects=False,
+                           allow_nonstandard_methods=True
+                           )
+
+    assert_http_response(mock_fetch, expected)
+
+
+@pytest.mark.asyncio
+@patch('tornado.httpclient.AsyncHTTPClient.fetch', new_callable=CoroutineMock)
+async def test_get_with_encoded_uri(mock_fetch, mock_session):
+    # Given
+    upstream_request = HTTPServerRequest(
+        method='GET',
+        uri='/awsproxy/bucket-name-1/ll%3A%3Askeleton%201.png',
+        headers=HTTPHeaders({
+            'Authorization': 'AWS4-HMAC-SHA256 '
+                             'Credential=AKIDEXAMPLE/20190816/us-west-2/s3/aws4_request, '
+                             'SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-user-agent, '
+                             'Signature=822f116d22d577aa2dc1033f354fa2a6fd3a2b6a0fd51885472b57daf45d605e',
+            'Host': 'localhost:8888',
+            'X-Amz-User-Agent': 'aws-sdk-js/2.507.0 promise',
+            'X-Amz-Content-Sha256': 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+            'X-Amz-Date': '20190816T224244Z'
+
+        }),
+        body=b'',
+        host='localhost:8888'
+    )
+
+    # When
+    await AwsProxyRequest(upstream_request, create_endpoint_resolver(), mock_session).execute_downstream()
+
+    # Then
+    expected = HTTPRequest(url='https://s3.us-west-2.amazonaws.com/bucket-name-1/ll%3A%3Askeleton%201.png',
+                           method=upstream_request.method,
+                           body=None,
+                           headers={
+                               'Authorization': 'AWS4-HMAC-SHA256 '
+                                                'Credential=access_key/20190816/us-west-2/s3/aws4_request, '
+                                                'SignedHeaders=host;x-amz-content-sha256;x-amz-date;'
+                                                'x-amz-security-token;x-amz-user-agent, '
+                                                'Signature='
+                                                '01f3a5107b8c445de48ebb0d902fe18539b643e9136094923250ca2b12666fe8',
+                               'X-Amz-User-Agent': upstream_request.headers['X-Amz-User-Agent'],
+                               'X-Amz-Content-Sha256': upstream_request.headers['X-Amz-Content-Sha256'],
+                               'X-Amz-Date': upstream_request.headers['X-Amz-Date'],
+                               'X-Amz-Security-Token': 'session_token',
+                               'Host': 's3.us-west-2.amazonaws.com'
+                           },
+                           follow_redirects=False,
+                           allow_nonstandard_methods=True
                            )
 
     assert_http_response(mock_fetch, expected)
@@ -286,9 +497,10 @@ async def test_put(mock_fetch, mock_session):
 
 def assert_http_response(mock_fetch, expected_http_request):
     mock_fetch.assert_awaited_once()
-    actual_http_request = mock_fetch.await_args[0][0]
+    actual_http_request: HTTPRequest = mock_fetch.await_args[0][0]
     assert expected_http_request.url == actual_http_request.url
-    assert expected_http_request.headers == actual_http_request.headers
     assert expected_http_request.body == actual_http_request.body
     assert expected_http_request.method == actual_http_request.method
     assert expected_http_request.follow_redirects == actual_http_request.follow_redirects
+    assert expected_http_request.allow_nonstandard_methods == actual_http_request.allow_nonstandard_methods
+    assert expected_http_request.headers == actual_http_request.headers


### PR DESCRIPTION
*Description of changes:*

- Allow POST without body. E.g. https://docs.aws.amazon.com/AmazonS3/latest/API/mpUploadInitiate.html
  - This requires the use of Tornado client's `allow_nonstandard_options`
- Construct canonical query string correctly when there is no value, i.e., `?param` is changed to `?param=`
- Ensure no body in DELETE responses
- Proxy HEAD requests. E.g. https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketHEAD.html


*Testing Done*

- Added unit tests
- Tested various S3 APIs - Get/PutObject, ListBuckets, End-to-End multipart uploads, S3 Select, HeadBucket

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
