### PR TITLE
Support a whitelist of services to proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,23 @@ For S3, use the `s3ForcePathStyle` parameter during the client initialization
     }).promise();
 ```
 
+### Whitelisting
+
+On the server, the `AWS_JUPYTER_PROXY_WHITELISTED_SERVICES` environment variable can be used to whitelist the set of services allowed to be proxied through. This is opt-in - Not specifying this 
+environment variable will whitelist all services.
+
+```bash
+export AWS_JUPYTER_PROXY_WHITELISTED_SERVICES=sagemaker,s3
+jupyter-lab
+```
+
 ## Development
 
 Install all dev dependencies
 
 ```bash
 pip install -e ".[dev]"
-jupyter serverextension enable --py aws_jupyter_proxy
+jupyter serverextension enable --py aws_jupyter_proxy --sys-prefix
 ```
 
 Run unit tests using pytest

--- a/aws_jupyter_proxy/awsproxy.py
+++ b/aws_jupyter_proxy/awsproxy.py
@@ -150,7 +150,11 @@ class AwsProxyRequest(object):
             self.upstream_auth_info.service_name,
             self.upstream_auth_info.region,
         )
-        self.whitelisted_services = os.getenv("AWS_JUPYTER_PROXY_WHITELISTED_SERVICES")
+        self.whitelisted_services = (
+            os.getenv("AWS_JUPYTER_PROXY_WHITELISTED_SERVICES").strip(",").split(",")
+            if os.getenv("AWS_JUPYTER_PROXY_WHITELISTED_SERVICES") is not None
+            else None
+        )
 
     async def execute_downstream(self) -> HTTPResponse:
         """
@@ -161,10 +165,9 @@ class AwsProxyRequest(object):
         and some operations send such requests (such as S3.InitiateMultipartUpload)
         :return: the HTTPResponse
         """
-        if self.whitelisted_services is not None and self.service_info.service_name not in self.whitelisted_services.strip(
-            ","
-        ).split(
-            ","
+        if (
+            self.whitelisted_services is not None
+            and self.service_info.service_name not in self.whitelisted_services
         ):
             raise HTTPError(
                 403,

--- a/aws_jupyter_proxy/awsproxy.py
+++ b/aws_jupyter_proxy/awsproxy.py
@@ -150,6 +150,7 @@ class AwsProxyRequest(object):
             self.upstream_auth_info.service_name,
             self.upstream_auth_info.region,
         )
+        # if the environment variable is not specified, os.getenv returns None, and no whitelist is in effect.
         self.whitelisted_services = (
             os.getenv("AWS_JUPYTER_PROXY_WHITELISTED_SERVICES").strip(",").split(",")
             if os.getenv("AWS_JUPYTER_PROXY_WHITELISTED_SERVICES") is not None

--- a/aws_jupyter_proxy/awsproxy.py
+++ b/aws_jupyter_proxy/awsproxy.py
@@ -1,5 +1,6 @@
 import hashlib
 import hmac
+import os
 from collections import namedtuple
 from functools import lru_cache
 from typing import List, Tuple
@@ -16,6 +17,7 @@ from tornado.httpclient import (
     HTTPRequest,
     HTTPResponse,
     HTTPClientError,
+    HTTPError,
 )
 from tornado.httputil import HTTPServerRequest, HTTPHeaders
 
@@ -148,6 +150,7 @@ class AwsProxyRequest(object):
             self.upstream_auth_info.service_name,
             self.upstream_auth_info.region,
         )
+        self.whitelisted_services = os.getenv("AWS_JUPYTER_PROXY_WHITELISTED_SERVICES")
 
     async def execute_downstream(self) -> HTTPResponse:
         """
@@ -158,6 +161,16 @@ class AwsProxyRequest(object):
         and some operations send such requests (such as S3.InitiateMultipartUpload)
         :return: the HTTPResponse
         """
+        if self.whitelisted_services is not None and self.service_info.service_name not in self.whitelisted_services.strip(
+            ","
+        ).split(
+            ","
+        ):
+            raise HTTPError(
+                403,
+                message=f"Service {self.service_info.service_name} is not whitelisted for proxying requests",
+            )
+
         downstream_request_path = self.upstream_request.path[len("/awsproxy") :] or "/"
         return await AsyncHTTPClient().fetch(
             HTTPRequest(


### PR DESCRIPTION
* An environment variable "AWS_JUPYTER_PROXY_WHITELISTED_SERVICES" is used to determine the list of services to whitelist
* For now this is opt-in; A None environment variable will proxy all requests