### PR TITLE
Update README.md for XSRF token usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,16 +32,10 @@ Using this requries no additional dependencies in the client-side code. Just use
     import * as AWS from 'aws-sdk';
     import SageMaker from 'aws-sdk/clients/sagemaker';
 
-    // Generic function to get a cookie value, needed for accessing the XSRF token
-    function getCookie(name: string) {
-      // from tornado docs: http://www.tornadoweb.org/en/stable/guide/security.html
-      var r = document.cookie.match("\\b" + name + "=([^;]*)\\b");
-      return r ? r[1] : undefined;
-    }
-
     // Reusable function to add the XSRF token header to a request
     function addXsrfToken<D, E>(request: AWS.Request<D, E>) {
-      const xsrfToken = getCookie('_xsrf');
+      const cookie = document.cookie.match('\\b' + '_xsrf' + '=([^;]*)\\b');
+      const xsrfToken = cookie ? cookie[1] : undefined;
       if (xsrfToken !== undefined) {
         request.httpRequest.headers['X-XSRFToken'] = xsrfToken;
       }


### PR DESCRIPTION
This change updates usage examples to pass the `X-XSRFToken` header in requests. Without this header, requests will not be proxied. This documentation is useful because JupyterLab enables XSRF security by default so users are likely to encounter the failure otherwise.

Ideally there is a way to register a middleware to add the token for every request automatically, but I was unable to find such a feature in preliminary searches, so I resorted to calling a reusable function for each request.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.