### PR TITLE
Add missing "refs/tags" requirement to test step

### DIFF
--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -40,6 +40,7 @@ jobs:
         --outdir dist/
         .
     - name: Publish distribution to test pypi
+      if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@master
       with:
         user: __token__


### PR DESCRIPTION
The "refs/tags" requirement is needed in both the test and publish steps. Not having it in the test workflow step is blocking publishing to PyPI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
