### PR TITLE
Add endpoint to get aws region config

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,4 +1,4 @@
-name: Build and test feature branch
+name: pull-request-build
 
 on:
   pull_request:

--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -1,7 +1,7 @@
 # Github actions that run tests on each commit, and publish to PyPi on tagged releases
 # build using https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
 
-name: Test and Release to PyPi
+name: build
 
 on:
   push

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # AWS Jupyter Proxy
 
+![Build](https://github.com/aws/aws-jupyter-proxy/workflows/build/badge.svg)
 [![Version](https://img.shields.io/pypi/v/aws_jupyter_proxy.svg)](https://pypi.org/project/aws-jupyter-proxy/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 

--- a/aws_jupyter_proxy/awsconfig.py
+++ b/aws_jupyter_proxy/awsconfig.py
@@ -1,0 +1,13 @@
+import json
+from botocore.session import get_session
+from notebook.base.handlers import APIHandler
+
+
+class AwsConfigHandler(APIHandler):
+    async def get(self, *args):
+        response = {"region": self._get_aws_region()}
+        self.write(json.dumps(response))
+
+    def _get_aws_region(self):
+        session = get_session()
+        return session.get_config_variable("region") or None

--- a/aws_jupyter_proxy/handlers.py
+++ b/aws_jupyter_proxy/handlers.py
@@ -2,13 +2,19 @@ from botocore.session import Session
 from notebook.utils import url_path_join
 
 from aws_jupyter_proxy.awsproxy import create_endpoint_resolver, AwsProxyHandler
+from aws_jupyter_proxy.awsconfig import AwsConfigHandler
 
 awsproxy_handlers = [
+    (
+        "/awsproxy/awsconfig",
+        AwsConfigHandler,
+        None,
+    ),
     (
         r"/awsproxy(.*)",
         AwsProxyHandler,
         dict(endpoint_resolver=create_endpoint_resolver(), session=Session()),
-    )
+    ),
 ]
 
 

--- a/tests/unit/test_awsconfig.py
+++ b/tests/unit/test_awsconfig.py
@@ -1,0 +1,31 @@
+from unittest.mock import patch
+from tornado.testing import AsyncHTTPTestCase
+from tornado.web import Application
+from aws_jupyter_proxy.awsconfig import AwsConfigHandler
+from aws_jupyter_proxy.handlers import awsproxy_handlers
+
+
+class TestHelloApp(AsyncHTTPTestCase):
+    def get_app(self):
+        return Application(awsproxy_handlers)
+
+    @patch("aws_jupyter_proxy.awsconfig.get_session")
+    def test_valid_region(self, mock_get_session):
+        mock_get_session.return_value.get_config_variable.return_value = "us-west-1"
+        response = self.fetch("/awsproxy/awsconfig")
+        self.assertEqual(response.code, 200)
+        self.assertEqual(response.body, b'{"region": "us-west-1"}')
+
+    @patch("aws_jupyter_proxy.awsconfig.get_session")
+    def test_default_region(self, mock_get_session):
+        mock_get_session.return_value.get_config_variable.return_value = ""
+        response = self.fetch("/awsproxy/awsconfig")
+        self.assertEqual(response.code, 200)
+        self.assertEqual(response.body, b'{"region": null}')
+
+    @patch("aws_jupyter_proxy.awsconfig.get_session")
+    def test_no_region(self, mock_get_session):
+        mock_get_session.return_value.get_config_variable.return_value = None
+        response = self.fetch("/awsproxy/awsconfig")
+        self.assertEqual(response.code, 200)
+        self.assertEqual(response.body, b'{"region": null}')


### PR DESCRIPTION
Added a new api endpoint to get region settings on server running aws jupyter proxy

* This gives the client extension the ability to call this endpoint to get region settings in local aws configuration set on the jupyter server using `aws configure set region "us-west-1"`, or set automatically in resources like ec2 instances.

* This also gives the client extension the ability to initialize aws sdk with a dynamic value for region.