### PR TITLE
Fixed broken request path from notebook with base url

### DIFF
--- a/aws_jupyter_proxy/awsproxy.py
+++ b/aws_jupyter_proxy/awsproxy.py
@@ -176,9 +176,9 @@ class AwsProxyRequest(object):
             )
 
         base_service_url = urlparse(self.service_info.endpoint_url)
+        start_index = self.upstream_request.path.index("/awsproxy") + len("/awsproxy")
         downstream_request_path = (
-            base_service_url.path + self.upstream_request.path[len("/awsproxy") :]
-            or "/"
+            base_service_url.path + self.upstream_request.path[start_index:] or "/"
         )
         return await AsyncHTTPClient().fetch(
             HTTPRequest(

--- a/tests/unit/test_awsproxy.py
+++ b/tests/unit/test_awsproxy.py
@@ -663,6 +663,61 @@ async def test_request_whitelisted(mock_getenv, mock_fetch, mock_session):
     assert_http_response(mock_fetch, expected)
 
 
+@pytest.mark.asyncio
+@patch("tornado.httpclient.AsyncHTTPClient.fetch", new_callable=CoroutineMock)
+@patch("os.getenv")
+async def test_request_with_base_url(mock_getenv, mock_fetch, mock_session):
+    # Given
+    upstream_request = HTTPServerRequest(
+        method="HEAD",
+        uri="base-url/awsproxy/bucket-name-1",
+        headers=HTTPHeaders(
+            {
+                "Authorization": "AWS4-HMAC-SHA256 "
+                "Credential=AKIDEXAMPLE/20190828/us-west-2/s3/aws4_request, "
+                "SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-user-agent, "
+                "Signature=0d02795c4feed38e5a4cd80aec3a2c67886b11797a23c307e4f52c2cfe0c137e",
+                "Host": "localhost:8888",
+                "X-Amz-User-Agent": "aws-sdk-js/2.507.0 promise",
+                "X-Amz-Content-Sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "X-Amz-Date": "20190828T173626Z",
+            }
+        ),
+        body=None,
+        host="localhost:8888",
+    )
+    mock_getenv.return_value = "s3,"
+
+    # When
+    await AwsProxyRequest(
+        upstream_request, create_endpoint_resolver(), mock_session
+    ).execute_downstream()
+
+    # Then
+    expected = HTTPRequest(
+        url="https://s3.us-west-2.amazonaws.com/bucket-name-1",
+        method=upstream_request.method,
+        body=None,
+        headers={
+            "Authorization": "AWS4-HMAC-SHA256 "
+            "Credential=access_key/20190828/us-west-2/s3/aws4_request, "
+            "SignedHeaders=host;x-amz-content-sha256;x-amz-date;"
+            "x-amz-security-token;x-amz-user-agent, "
+            "Signature="
+            "6d724e3bd64390d5d84010d6fc0f8147b3e3917c5befa3f8d1efb691b408e821",
+            "X-Amz-User-Agent": upstream_request.headers["X-Amz-User-Agent"],
+            "X-Amz-Content-Sha256": upstream_request.headers["X-Amz-Content-Sha256"],
+            "X-Amz-Date": upstream_request.headers["X-Amz-Date"],
+            "X-Amz-Security-Token": "session_token",
+            "Host": "s3.us-west-2.amazonaws.com",
+        },
+        follow_redirects=False,
+        allow_nonstandard_methods=True,
+    )
+
+    assert_http_response(mock_fetch, expected)
+
+
 def assert_http_response(mock_fetch, expected_http_request):
     mock_fetch.assert_awaited_once()
     actual_http_request: HTTPRequest = mock_fetch.await_args[0][0]


### PR DESCRIPTION
### Issue

The derived downstream request path is incorrect for upstream request paths that contain Jupyter notebook base URL. For example, if the the upstream request path is `asdf/awsproxy/...`, the derived downstream removes the first 8 characters (the length of the string "/awsproxy") as it assumes it always just starts with "/awsproxy".

### Solution

Consider that the upstream request path contains a base url. Find (1) the index of "/awsproxy", (2) the length of "/awsproxy". The sum of (1) and (2) is the starting index of the substring to derive the downstream request path.