### PR TITLE
updated read me for s3 usages

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ For S3, use the `s3ForcePathStyle` parameter during the client initialization
     const s3Client = new S3({
         region: 'us-west-2',
         endpoint: proxyEndpoint,
-        s3ForcePathStyle: true
+        s3ForcePathStyle: true,
+        s3DisableBodySigning:false // for https
     });
 
     await s3Client


### PR DESCRIPTION
For S3 service call updated read me to allow body signing for request over https to mitigate signature mismatch issue

`SignatureDoesNotMatch: The request signature we calculated does not match the signature you provided. Check your key 
 and signing method.`
