### PR TITLE
chore: release aws-jupyter-proxy 0.3.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="aws_jupyter_proxy",
-    version="0.3.1",
+    version="0.3.2",
     url="https://github.com/aws/aws-jupyter-proxy",
     author="Amazon Web Services",
     description="A Jupyter server extension to proxy requests with AWS SigV4 authentication",


### PR DESCRIPTION
Releases aws-jupyter-proxy 0.3.2

*Description of changes:*
Changes version number in setup file, uses github workflows release process.


Releases the following commits:
- https://github.com/aws/aws-jupyter-proxy/commit/4dbfdfd8ba32c3127ad076c6e9757b628a33b070
- https://github.com/aws/aws-jupyter-proxy/commit/65fe5ca6d97b53999fa6fa6e8289745a434d1539
- https://github.com/aws/aws-jupyter-proxy/pull/20
- 
- https://jira.hil.aws.dev/browse/AXIS-1472



