### PR TITLE
feat: Update aws-jupyter-proxy to allow for endpoint override

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,14 @@ setuptools.setup(
     license="Apache License 2.0",
     install_requires=["notebook >=6.0, <7.0", "botocore >=1.0, <2.0"],
     extras_require={
-        "dev": ["asynctest", "black", "pytest", "pytest-asyncio", "pytest-cov"]
+        "dev": [
+            "asynctest",
+            "black",
+            "pytest",
+            "pytest-asyncio",
+            "pytest-cov",
+            "validators",
+        ]
     },
     python_requires=">=3.6",
     data_files=[

--- a/tests/unit/test_awsproxy.py
+++ b/tests/unit/test_awsproxy.py
@@ -74,6 +74,63 @@ async def test_post_with_body(mock_fetch, mock_session):
 
 @pytest.mark.asyncio
 @patch("tornado.httpclient.AsyncHTTPClient.fetch", new_callable=CoroutineMock)
+async def test_endpoint_override(mock_fetch, mock_session):
+    # Given
+    upstream_request = HTTPServerRequest(
+        method="POST",
+        uri="/awsproxy",
+        headers=HTTPHeaders(
+            {
+                "Authorization": "AWS4-HMAC-SHA256 "
+                "Credential=AKIDEXAMPLE/20190816/us-west-2/sagemaker/aws4_request, "
+                "SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-target;x-amz-user-agent, "
+                "Signature=cfe54b727d00698b9940531b1c9e456fd70258adc41fb338896455fddd6f3f2f",
+                "Host": "localhost:8888",
+                "X-Amz-User-Agent": "aws-sdk-js/2.507.0 promise",
+                "X-Amz-Content-Sha256": "a83a35dcbd19cfad5b714cb12b5275a4cfa7e1012b633d9206300f09e058e7fa",
+                "X-Amz-Target": "SageMaker.ListNotebookInstances",
+                "X-Amz-Date": "20190816T204930Z",
+                "X-service-endpoint-url": "https://axis.us-west-2.amazonaws.com",
+            }
+        ),
+        body=b'{"NameContains":"myname"}',
+        host="localhost:8888",
+    )
+
+    # When
+    await AwsProxyRequest(
+        upstream_request, create_endpoint_resolver(), mock_session
+    ).execute_downstream()
+
+    # Then
+    expected = HTTPRequest(
+        url="https://axis.us-west-2.amazonaws.com/",
+        method=upstream_request.method,
+        body=b'{"NameContains":"myname"}',
+        headers={
+            "Authorization": "AWS4-HMAC-SHA256 "
+            "Credential=access_key/20190816/us-west-2/sagemaker/aws4_request, "
+            "SignedHeaders=host;x-amz-content-sha256;x-amz-date;"
+            "x-amz-security-token;x-amz-target;x-amz-user-agent, "
+            "Signature="
+            "e21ff53bc657eaa68ee08193cccdeb82027692d45d6ea57a5c3364e7fc95954e",
+            "X-Amz-User-Agent": "aws-sdk-js/2.507.0 promise",
+            "X-Amz-Content-Sha256": "a83a35dcbd19cfad5b714cb12b5275a4cfa7e1012b633d9206300f09e058e7fa",
+            "X-Amz-Target": "SageMaker.ListNotebookInstances",
+            "X-Amz-Date": "20190816T204930Z",
+            "X-Service-Endpoint-Url": "https://axis.us-west-2.amazonaws.com",
+            "Host": "axis.us-west-2.amazonaws.com",
+            "X-Amz-Security-Token": "session_token",
+        },
+        follow_redirects=False,
+        allow_nonstandard_methods=True,
+    )
+
+    assert_http_response(mock_fetch, expected)
+
+
+@pytest.mark.asyncio
+@patch("tornado.httpclient.AsyncHTTPClient.fetch", new_callable=CoroutineMock)
 async def test_errors_passed_through(mock_fetch, mock_session):
     # Given
     upstream_request = HTTPServerRequest(


### PR DESCRIPTION
Allowing endpoint override for aws-jupyter-proxy

*Description of changes:*
`X-service-endpoint-url` header overrides proxy request endpoint
- Input validation is preformed on endpoint to make sure it is valid endpoint and AWS controlled



There are a few verifications:
- Our team has used the endpoint override successfully within UI.
- Jest test that shows endpoint override and no regressions https://github.com/aws/aws-jupyter-proxy/pull/21/commits/679f58b6eb9d3313005d5117ae387ea563daebef
- One can install the new version of aws-jupyter-proxy in studio by following the steps in https://tiny.amazon.com/oswigc9t/
  -  For extra verification, one can build the new version of aws-jupyter-proxy by running python -m build then installing the .whl file exported into Studio. It follows the above instructions as well
  -  Make a network call with a X-service-endpoint-url header specified and the call will be towards the header’s value.

Let me know if one needs help demoing. I can show the difference in my local Studio.