### PR TITLE
fix: removing validators package usage to fix 404 error

### DIFF
--- a/aws_jupyter_proxy/awsproxy.py
+++ b/aws_jupyter_proxy/awsproxy.py
@@ -1,7 +1,6 @@
 import hashlib
 import hmac
 import os
-import validators
 import re
 from collections import namedtuple
 from functools import lru_cache
@@ -48,10 +47,9 @@ def get_service_info(
         region_name=region,
     )
 
-    if (
-        endpoint_override
-        and validators.url(endpoint_override)
-        and re.compile(".*\.(aws.dev|amazonaws.com)$").match(endpoint_override)
+    if endpoint_override and re.fullmatch(
+        r"https:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.(aws.dev|amazonaws.com)\b",
+        endpoint_override,
     ):
         service_data["endpoint_url"] = endpoint_override
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="aws_jupyter_proxy",
-    version="0.3.2",
+    version="0.3.3",
     url="https://github.com/aws/aws-jupyter-proxy",
     author="Amazon Web Services",
     description="A Jupyter server extension to proxy requests with AWS SigV4 authentication",
@@ -21,7 +21,6 @@ setuptools.setup(
             "pytest",
             "pytest-asyncio",
             "pytest-cov",
-            "validators",
         ]
     },
     python_requires=">=3.6",

--- a/tests/unit/test_awsproxy.py
+++ b/tests/unit/test_awsproxy.py
@@ -74,7 +74,7 @@ async def test_post_with_body(mock_fetch, mock_session):
 
 @pytest.mark.asyncio
 @patch("tornado.httpclient.AsyncHTTPClient.fetch", new_callable=CoroutineMock)
-async def test_endpoint_override(mock_fetch, mock_session):
+async def test_success_endpoint_override(mock_fetch, mock_session):
     # Given
     upstream_request = HTTPServerRequest(
         method="POST",
@@ -120,6 +120,120 @@ async def test_endpoint_override(mock_fetch, mock_session):
             "X-Amz-Date": "20190816T204930Z",
             "X-Service-Endpoint-Url": "https://axis.us-west-2.amazonaws.com",
             "Host": "axis.us-west-2.amazonaws.com",
+            "X-Amz-Security-Token": "session_token",
+        },
+        follow_redirects=False,
+        allow_nonstandard_methods=True,
+    )
+
+    assert_http_response(mock_fetch, expected)
+
+
+@pytest.mark.asyncio
+@patch("tornado.httpclient.AsyncHTTPClient.fetch", new_callable=CoroutineMock)
+async def test_wrongurl_endpoint_override(mock_fetch, mock_session):
+    # Given
+    upstream_request = HTTPServerRequest(
+        method="POST",
+        uri="/awsproxy",
+        headers=HTTPHeaders(
+            {
+                "Authorization": "AWS4-HMAC-SHA256 "
+                "Credential=AKIDEXAMPLE/20190816/us-west-2/sagemaker/aws4_request, "
+                "SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-target;x-amz-user-agent, "
+                "Signature=cfe54b727d00698b9940531b1c9e456fd70258adc41fb338896455fddd6f3f2f",
+                "Host": "localhost:8888",
+                "X-Amz-User-Agent": "aws-sdk-js/2.507.0 promise",
+                "X-Amz-Content-Sha256": "a83a35dcbd19cfad5b714cb12b5275a4cfa7e1012b633d9206300f09e058e7fa",
+                "X-Amz-Target": "SageMaker.ListNotebookInstances",
+                "X-Amz-Date": "20190816T204930Z",
+                "X-service-endpoint-url": "https://aws.amazon.com",
+            }
+        ),
+        body=b'{"NameContains":"myname"}',
+        host="localhost:8888",
+    )
+
+    # When
+    await AwsProxyRequest(
+        upstream_request, create_endpoint_resolver(), mock_session
+    ).execute_downstream()
+
+    # Then
+    expected = HTTPRequest(
+        url="https://api.sagemaker.us-west-2.amazonaws.com/",
+        method=upstream_request.method,
+        body=b'{"NameContains":"myname"}',
+        headers={
+            "Authorization": "AWS4-HMAC-SHA256 "
+            "Credential=access_key/20190816/us-west-2/sagemaker/aws4_request, "
+            "SignedHeaders=host;x-amz-content-sha256;x-amz-date;"
+            "x-amz-security-token;x-amz-target;x-amz-user-agent, "
+            "Signature="
+            "215b2e3656147651194acb6cca20d5cb01dd8f396ac941533fc3e52b7cb563dc",
+            "X-Amz-User-Agent": "aws-sdk-js/2.507.0 promise",
+            "X-Amz-Content-Sha256": "a83a35dcbd19cfad5b714cb12b5275a4cfa7e1012b633d9206300f09e058e7fa",
+            "X-Amz-Target": "SageMaker.ListNotebookInstances",
+            "X-Amz-Date": "20190816T204930Z",
+            "X-Service-Endpoint-Url": "https://aws.amazon.com",
+            "Host": "api.sagemaker.us-west-2.amazonaws.com",
+            "X-Amz-Security-Token": "session_token",
+        },
+        follow_redirects=False,
+        allow_nonstandard_methods=True,
+    )
+
+    assert_http_response(mock_fetch, expected)
+
+
+@pytest.mark.asyncio
+@patch("tornado.httpclient.AsyncHTTPClient.fetch", new_callable=CoroutineMock)
+async def test_nonhttp_endpoint_override(mock_fetch, mock_session):
+    # Given
+    upstream_request = HTTPServerRequest(
+        method="POST",
+        uri="/awsproxy",
+        headers=HTTPHeaders(
+            {
+                "Authorization": "AWS4-HMAC-SHA256 "
+                "Credential=AKIDEXAMPLE/20190816/us-west-2/sagemaker/aws4_request, "
+                "SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-target;x-amz-user-agent, "
+                "Signature=cfe54b727d00698b9940531b1c9e456fd70258adc41fb338896455fddd6f3f2f",
+                "Host": "localhost:8888",
+                "X-Amz-User-Agent": "aws-sdk-js/2.507.0 promise",
+                "X-Amz-Content-Sha256": "a83a35dcbd19cfad5b714cb12b5275a4cfa7e1012b633d9206300f09e058e7fa",
+                "X-Amz-Target": "SageMaker.ListNotebookInstances",
+                "X-Amz-Date": "20190816T204930Z",
+                "X-service-endpoint-url": "http://axis.us-west-2.amazonaws.com",
+            }
+        ),
+        body=b'{"NameContains":"myname"}',
+        host="localhost:8888",
+    )
+
+    # When
+    await AwsProxyRequest(
+        upstream_request, create_endpoint_resolver(), mock_session
+    ).execute_downstream()
+
+    # Then
+    expected = HTTPRequest(
+        url="https://api.sagemaker.us-west-2.amazonaws.com/",
+        method=upstream_request.method,
+        body=b'{"NameContains":"myname"}',
+        headers={
+            "Authorization": "AWS4-HMAC-SHA256 "
+            "Credential=access_key/20190816/us-west-2/sagemaker/aws4_request, "
+            "SignedHeaders=host;x-amz-content-sha256;x-amz-date;"
+            "x-amz-security-token;x-amz-target;x-amz-user-agent, "
+            "Signature="
+            "215b2e3656147651194acb6cca20d5cb01dd8f396ac941533fc3e52b7cb563dc",
+            "X-Amz-User-Agent": "aws-sdk-js/2.507.0 promise",
+            "X-Amz-Content-Sha256": "a83a35dcbd19cfad5b714cb12b5275a4cfa7e1012b633d9206300f09e058e7fa",
+            "X-Amz-Target": "SageMaker.ListNotebookInstances",
+            "X-Amz-Date": "20190816T204930Z",
+            "X-Service-Endpoint-Url": "http://axis.us-west-2.amazonaws.com",
+            "Host": "api.sagemaker.us-west-2.amazonaws.com",
             "X-Amz-Security-Token": "session_token",
         },
         follow_redirects=False,


### PR DESCRIPTION
Allowing endpoint override for aws-jupyter-proxy

*Description of changes:*
Removing validators package
- Adding URL regex adapted from second answer of https://stackoverflow.com/questions/7160737/how-to-validate-a-url-in-python-malformed-or-not
- Validators package was throwing error leading to Console 404 on Studio Launch
Raising version number to 0.3.3


Verification:
- One can install the new version of aws-jupyter-proxy in studio by following the steps in https://tiny.amazon.com/10rg5bv0/
  -  Make a network call with a X-service-endpoint-url header specified and the call will be towards the header’s value.

Let me know if one needs help demoing. I can show the difference in my local Studio.