### PR TITLE
feat: add content security policy reccomendations to requests without csp

### DIFF
--- a/aws_jupyter_proxy/awsproxy.py
+++ b/aws_jupyter_proxy/awsproxy.py
@@ -99,6 +99,10 @@ class AwsProxyHandler(APIHandler):
             if self._is_blacklisted_response_header(name, value):
                 continue
             self.set_header(name, value)
+        csp_value = response.headers.get(
+            "Content-Security-Policy", "upgrade-insecure-requests; base-uri 'none';"
+        )
+        self.set_header("Content-Security-Policy", csp_value)
         super(APIHandler, self).finish(response.body or None)
 
     async def post(self, *args):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="aws_jupyter_proxy",
-    version="0.3.3",
+    version="0.3.4",
     url="https://github.com/aws/aws-jupyter-proxy",
     author="Amazon Web Services",
     description="A Jupyter server extension to proxy requests with AWS SigV4 authentication",


### PR DESCRIPTION
Commit summary:

feat: add content security policy reccomendations to requests without csp

Description of changes:

- Adding "upgrade-insecure-requests; base-uri 'none';" to content security policy
- Upgrading to 0.3.4

Why:
- These are security enhancements for aws-jupyter-proxy client/server interactions
 - `upgrade-insecure-requests;` Replace insecure traffic (served over HTTP) with secure traffic
 - `base-uri 'none';` Restricts the URLs which can be used in a document's <base> element

Verification:

- Run python -m build on master branch of https://github.com/danpilgrim-aws/aws-jupyter-proxy to produce .whl file
- Verify it is commit e9e15005438cd489779821ea8cc0c407cdc742fb
- Install the new version of aws-jupyter-proxy in studio by following the steps similar to those in https://quip-amazon.com/R23FATWP96c5/AXIS-M8-BugBash#temp:C:cbB5891fd28f26a4c29ba944033f to install the 0.3.4 build .whl file.
```
pip uninstall aws_jupyter_proxy -y
pip install aws_jupyter_proxy-0.3.4-py3-none-any.whl
nohup supervisorctl -c /etc/supervisor/conf.d/supervisord.conf restart jupyterlabserver > /dev/null 2>&1 &
```
- Use pip list to verify aws_jupyter_proxy-0.3.4 is installed
- Make a network call through Axis without Content-Security-Policy header specified and the call will have a content security policy specified when returned