### PR TITLE
fix: missing headers return 400 bad request

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Python 3
       uses: actions/setup-python@v2
       with:
-        python-version: 3.X
+        python-version: "3.10"
         
     - name: Install dependencies
       run: |

--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python 3
       uses: actions/setup-python@v2
       with:
-        python-version: 3.X
+        python-version: "3.10"
         
     - name: Install dependencies
       run: |

--- a/aws_jupyter_proxy/awsproxy.py
+++ b/aws_jupyter_proxy/awsproxy.py
@@ -328,9 +328,12 @@ class AwsProxyRequest(object):
         canonical_headers = {}
 
         for signed_header in self.upstream_auth_info.signed_headers:
-            canonical_headers[signed_header] = self.upstream_request.headers[
-                signed_header
-            ]
+            try:
+                canonical_headers[signed_header] = self.upstream_request.headers[
+                    signed_header
+                ]
+            except KeyError:
+                raise HTTPError(400, message=f"Bad Request")
 
         base_service_url = urlparse(self.service_info.endpoint_url)
         canonical_headers["host"] = base_service_url.netloc

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="aws_jupyter_proxy",
-    version="0.3.5",
+    version="0.3.6",
     url="https://github.com/aws/aws-jupyter-proxy",
     author="Amazon Web Services",
     description="A Jupyter server extension to proxy requests with AWS SigV4 authentication",


### PR DESCRIPTION
Commit summary:

fix: missing headers return 400 bad request

Description of changes:

Adding error catching to signed canonical header parsing
Upgrading to 0.3.6

Why:

This is a security patch for aws-jupyter-proxy client/server interactions. Previously, missing headers would return a stack trace along with error

Verification:

Run the following commands on master branch of https://github.com/danpilgrim-aws/aws-jupyter-proxy to produce .whl file
```
aws codeartifact login --tool pip --domain-owner 149122183214 --domain amazon --repository shared --region us-west-2
python -m build
```
Verify it is commit https://github.com/aws/aws-jupyter-proxy/commit/729faa9cb7a1d4882cfbcf62b0a67aca6f0e10ac
Install the new version of aws-jupyter-proxy in studio by following the steps similar to those in https://quip-amazon.com/R23FATWP96c5/AXIS-M8-BugBash#temp:C:cbB5891fd28f26a4c29ba944033f to install the 0.3.6 build .whl file.
```
pip uninstall aws_jupyter_proxy -y
pip install aws_jupyter_proxy-0.3.6-py3-none-any.whl --user
nohup supervisorctl -c /etc/supervisor/conf.d/supervisord.conf restart jupyterlabserver > /dev/null 2>&1 &
```
Use `pip list` to verify aws_jupyter_proxy-0.3.6 is installed
Explore making different network calls, we created axis network call testing listEarthObservationJobs through aws-jupyter-proxy.