### PR TITLE
fix: missing Auth header returns 400 Bad Request

### DIFF
--- a/aws_jupyter_proxy/awsproxy.py
+++ b/aws_jupyter_proxy/awsproxy.py
@@ -378,10 +378,21 @@ class AwsProxyRequest(object):
 
         :return: the UpstreamAuthInfo instance
         """
-        auth_header_parts = self.upstream_request.headers["Authorization"].split(" ")
 
-        signed_headers = auth_header_parts[2].strip(",").split("=")[1].split(";")
-        _, _, region, service_name, _ = auth_header_parts[1].split("=")[1].split("/")
+        try:
+            auth_header_parts = self.upstream_request.headers["Authorization"].split(
+                " "
+            )
+
+            signed_headers = auth_header_parts[2].strip(",").split("=")[1].split(";")
+            _, _, region, service_name, _ = (
+                auth_header_parts[1].split("=")[1].split("/")
+            )
+        except KeyError:
+            raise HTTPError(400, message=f"Missing Authorization header")
+        except (IndexError, ValueError):
+            raise HTTPError(400, message=f"Malformed Authorization header")
+
         return UpstreamAuthInfo(service_name, region, signed_headers)
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="aws_jupyter_proxy",
-    version="0.3.6",
+    version="0.3.7",
     url="https://github.com/aws/aws-jupyter-proxy",
     author="Amazon Web Services",
     description="A Jupyter server extension to proxy requests with AWS SigV4 authentication",

--- a/tests/unit/test_awsproxy.py
+++ b/tests/unit/test_awsproxy.py
@@ -889,6 +889,133 @@ async def test_request_with_base_url(mock_getenv, mock_fetch, mock_session):
     assert_http_response(mock_fetch, expected)
 
 
+@pytest.mark.asyncio
+@patch("os.getenv")
+async def test_missing_authorization_header(mock_getenv, mock_session):
+    # Given
+    upstream_request = HTTPServerRequest(
+        method="HEAD",
+        uri="/awsproxy/bucket-name-1",
+        headers=HTTPHeaders(
+            {
+                "Host": "localhost:8888",
+                "X-Amz-User-Agent": "aws-sdk-js/2.507.0 promise",
+                "X-Amz-Content-Sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "X-Amz-Date": "20190828T173626Z",
+            }
+        ),
+        body=None,
+        host="localhost:8888",
+    )
+    mock_getenv.return_value = ""
+
+    # When
+    with pytest.raises(HTTPError) as e:
+        await AwsProxyRequest(
+            upstream_request, create_endpoint_resolver(), mock_session
+        ).execute_downstream()
+
+        # Then
+        assert 400 == e.value.code
+        assert "Missing Authorization header" == e.value.message
+
+
+@pytest.mark.asyncio
+@patch("os.getenv")
+async def test_missing_region_in_authorization_header(mock_getenv, mock_session):
+    # Given
+    upstream_request = HTTPServerRequest(
+        method="HEAD",
+        uri="/awsproxy/bucket-name-1",
+        headers=HTTPHeaders(
+            {
+                "Host": "localhost:8888",
+                "X-Amz-User-Agent": "aws-sdk-js/2.507.0 promise",
+                "X-Amz-Content-Sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "X-Amz-Date": "20190828T173626Z",
+                "Authorization": "AWS4-HMAC-SHA256 Credential=IGNOREDIGNO/20230317/some-service/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-user-agent;x-service-endpoint-url;x-xsrftoken, Signature=123456789",
+            }
+        ),
+        body=None,
+        host="localhost:8888",
+    )
+    mock_getenv.return_value = ""
+
+    # When
+    with pytest.raises(HTTPError) as e:
+        await AwsProxyRequest(
+            upstream_request, create_endpoint_resolver(), mock_session
+        ).execute_downstream()
+
+        # Then
+        assert 400 == e.value.code
+        assert "Malformed Authorization header" == e.value.message
+
+
+@pytest.mark.asyncio
+@patch("os.getenv")
+async def test_missing_service_in_authorization_header(mock_getenv, mock_session):
+    # Given
+    upstream_request = HTTPServerRequest(
+        method="HEAD",
+        uri="/awsproxy/bucket-name-1",
+        headers=HTTPHeaders(
+            {
+                "Host": "localhost:8888",
+                "X-Amz-User-Agent": "aws-sdk-js/2.507.0 promise",
+                "X-Amz-Content-Sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "X-Amz-Date": "20190828T173626Z",
+                "Authorization": "AWS4-HMAC-SHA256 Credential=IGNOREDIGNO/20230317/us-west-2/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-user-agent;x-service-endpoint-url;x-xsrftoken, Signature=123456789",
+            }
+        ),
+        body=None,
+        host="localhost:8888",
+    )
+    mock_getenv.return_value = ""
+
+    # When
+    with pytest.raises(HTTPError) as e:
+        await AwsProxyRequest(
+            upstream_request, create_endpoint_resolver(), mock_session
+        ).execute_downstream()
+
+        # Then
+        assert 400 == e.value.code
+        assert "Malformed Authorization header" == e.value.message
+
+
+@pytest.mark.asyncio
+@patch("os.getenv")
+async def test_malformed_authorization_header(mock_getenv, mock_session):
+    # Given
+    upstream_request = HTTPServerRequest(
+        method="HEAD",
+        uri="/awsproxy/bucket-name-1",
+        headers=HTTPHeaders(
+            {
+                "Host": "localhost:8888",
+                "X-Amz-User-Agent": "aws-sdk-js/2.507.0 promise",
+                "X-Amz-Content-Sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "X-Amz-Date": "20190828T173626Z",
+                "Authorization": "AWS4-HMAC-SHA256 malformed-content",
+            }
+        ),
+        body=None,
+        host="localhost:8888",
+    )
+    mock_getenv.return_value = ""
+
+    # When
+    with pytest.raises(HTTPError) as e:
+        await AwsProxyRequest(
+            upstream_request, create_endpoint_resolver(), mock_session
+        ).execute_downstream()
+
+        # Then
+        assert 400 == e.value.code
+        assert "Malformed Authorization header" == e.value.message
+
+
 def assert_http_response(mock_fetch, expected_http_request):
     mock_fetch.assert_awaited_once()
     actual_http_request: HTTPRequest = mock_fetch.await_args[0][0]


### PR DESCRIPTION
**Commit summary:**

fix: missing Authorization header returns 400 Bad Request

**Description of changes:**

- Catch `KeyError` and `IndexError` when building auth headers, and return a `400 Bad Request`.
- Upgrade to v0.3.7.

**Why:**

Currently, if an upstream request is missing an `Authorization` header, a Python stack trace is returned in the response body.  This was flagged as a potential security vulnerability.  Similar to the issue fixed in https://github.com/aws/aws-jupyter-proxy/pull/26

We now catch `KeyError` and `IndexError` when building upstream request auth headers.  We don't expect customers to malform a request, so we deliberately return a vague error message.

**Verification:**

- Build a .whl with `python -m build`.
- Verify it is commit https://github.com/aws/aws-jupyter-proxy/commit/b96eeb37465474b9598052ea577c6db90758683c
- Install the .whl in SageMaker Studio.
- Verify 0.3.7 is installed with `pip list`.
- Make a network call to an AWS service using `aws_jupyter_proxy`, making sure that an `Authorization` header is missing.
- Observe that a `400 Bad Request` is returned.