### PR TITLE
fix: missing Auth header returns 400 Bad Request

### DIFF
--- a/aws_jupyter_proxy/awsproxy.py
+++ b/aws_jupyter_proxy/awsproxy.py
@@ -380,10 +380,14 @@ class AwsProxyRequest(object):
         """
 
         try:
-            auth_header_parts = self.upstream_request.headers["Authorization"].split(" ")
+            auth_header_parts = self.upstream_request.headers["Authorization"].split(
+                " "
+            )
 
             signed_headers = auth_header_parts[2].strip(",").split("=")[1].split(";")
-            _, _, region, service_name, _ = auth_header_parts[1].split("=")[1].split("/")
+            _, _, region, service_name, _ = (
+                auth_header_parts[1].split("=")[1].split("/")
+            )
         except (KeyError, IndexError):
             raise HTTPError(400, message=f"Bad Request")
 

--- a/aws_jupyter_proxy/awsproxy.py
+++ b/aws_jupyter_proxy/awsproxy.py
@@ -378,10 +378,15 @@ class AwsProxyRequest(object):
 
         :return: the UpstreamAuthInfo instance
         """
-        auth_header_parts = self.upstream_request.headers["Authorization"].split(" ")
 
-        signed_headers = auth_header_parts[2].strip(",").split("=")[1].split(";")
-        _, _, region, service_name, _ = auth_header_parts[1].split("=")[1].split("/")
+        try:
+            auth_header_parts = self.upstream_request.headers["Authorization"].split(" ")
+
+            signed_headers = auth_header_parts[2].strip(",").split("=")[1].split(";")
+            _, _, region, service_name, _ = auth_header_parts[1].split("=")[1].split("/")
+        except (KeyError, IndexError):
+            raise HTTPError(400, message=f"Bad Request")
+
         return UpstreamAuthInfo(service_name, region, signed_headers)
 
 

--- a/aws_jupyter_proxy/awsproxy.py
+++ b/aws_jupyter_proxy/awsproxy.py
@@ -388,8 +388,10 @@ class AwsProxyRequest(object):
             _, _, region, service_name, _ = (
                 auth_header_parts[1].split("=")[1].split("/")
             )
-        except (KeyError, IndexError):
-            raise HTTPError(400, message=f"Bad Request")
+        except (KeyError):
+            raise HTTPError(400, message=f"Missing Authorization header")
+        except (IndexError, ValueError):
+            raise HTTPError(400, message=f"Malformed Authorization header")
 
         return UpstreamAuthInfo(service_name, region, signed_headers)
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="aws_jupyter_proxy",
-    version="0.3.6",
+    version="0.3.7",
     url="https://github.com/aws/aws-jupyter-proxy",
     author="Amazon Web Services",
     description="A Jupyter server extension to proxy requests with AWS SigV4 authentication",


### PR DESCRIPTION
###  Commit summary:

fix: missing Authorization header returns 400 Bad Request

### Description of changes:

Catch KeyError and IndexError when building auth headers, and return a 400 Bad Request.
Upgrade to v0.3.7.

### Why:

Currently, if an upstream request is missing an Authorization header, a Python stack trace is returned in the response body. This was flagged as a potential security vulnerability. Similar to the issue fixed in https://github.com/aws/aws-jupyter-proxy/pull/26

We now catch KeyError and IndexError when building upstream request auth headers. We don't expect customers to malform a request, so we deliberately return a vague error message.

### Verification:

Build a .whl with python -m build.
Verify it is commit https://github.com/aws/aws-jupyter-proxy/commit/b96eeb37465474b9598052ea577c6db90758683c
Install the .whl in SageMaker Studio.
Verify 0.3.7 is installed with pip list.
Make a network call to an AWS service using aws_jupyter_proxy, making sure that an Authorization header is missing.
Observe that a 400 Bad Request is returned.