### PR TITLE
added aws.a2z.com sufix as allowlisted domain for endpoint override

### DIFF
--- a/aws_jupyter_proxy/awsproxy.py
+++ b/aws_jupyter_proxy/awsproxy.py
@@ -48,7 +48,7 @@ def get_service_info(
     )
 
     if endpoint_override and re.fullmatch(
-        r"https:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.(aws.dev|amazonaws.com)\b",
+        r"https:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.(aws.dev|amazonaws.com|aws.a2z.com)\b",
         endpoint_override,
     ):
         service_data["endpoint_url"] = endpoint_override


### PR DESCRIPTION
Updated regex rule to allow list domain ending with `aws.a2z.com`

Description of changes:

-  X-service-endpoint-url header overrides proxy request endpoint
- Added one more Input validation on endpoint to make sure it is valid endpoint and AWS controlled

There are a few verification:
- Tested by locally installing the extension in the SM studio and providing an endpoint ended with `aws.a2z.com` as a  `X-service-endpoint-url ` header